### PR TITLE
wording: "Parallel" & "Cross-eyed"

### DIFF
--- a/sbs.py
+++ b/sbs.py
@@ -15,7 +15,7 @@ class SideBySide:
                 "base_image": ("IMAGE",),
                 "depth_map": ("IMAGE",),
                 "depth_scale": ("INT", {"default": 30}),
-                "mode": (["Cross-eyed", "Fliped"], {}),
+                "mode": (["Parallel", "Cross-eyed"], {}),
             },
         }
 
@@ -32,7 +32,9 @@ class SideBySide:
         - base_image: numpy array representing the base image.
         - depth_map: numpy array representing the depth map.
         - depth_scale: integer representing the scaling factor for depth.
-        - flip side
+        - modes: 
+        "Parallel" = the right view angle is on the right side 
+        "Cross-eyed" = flipped
 
         Returns:
         - sbs_image: the stereoscopic image.
@@ -48,7 +50,7 @@ class SideBySide:
         # Get dimensions and resize depth map to match base image
         width, height = image.size
         depth_map_img = depth_map_img.resize((width, height), Image.NEAREST)
-        fliped = 0 if mode == "Cross-eyed" else width
+        fliped = 0 if mode == "Parallel" else width
 
         # Create an empty image for the side-by-side result
         sbs_image = np.zeros((height, width * 2, 3), dtype=np.uint8)


### PR DESCRIPTION
Corrected the wording for parallel and cross-eyed modes.
In parallel mode the image of the right "camera" eye is on the right side of the stereo image - in cross-eyed mode, the images are flipped. more info: https://triaxes.com/docs/3DTheory-en/522ParallelCrosseyedviewingmetho.html